### PR TITLE
Upgrade to pathwatcher 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mapbox.js": "1.6.x",
     "geojsonhint": "0.2.x",
     "fs-plus": "2.x",
-    "pathwatcher": "^1.0",
+    "pathwatcher": "^2.0.10",
     "underscore-plus": "1.x"
   }
 }


### PR DESCRIPTION
Allows this package to be installed into Atom 0.121.0+

See http://blog.atom.io/2014/08/13/chrome-and-node-upgrade.html for more details

Fixes #9
Fixes #10
